### PR TITLE
Declare variable at top of function scope in next()

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -493,11 +493,12 @@ rison.parser.prototype.table = {
 
 // return the next non-whitespace character, or undefined
 rison.parser.prototype.next = function () {
+    var c;
     var s = this.string;
     var i = this.index;
     do {
         if (i == s.length) return undefined;
-        var c = s.charAt(i++);
+        c = s.charAt(i++);
     } while (rison.parser.WHITESPACE.indexOf(c) >= 0);
     this.index = i;
     return c;


### PR DESCRIPTION
Since `var` definitions are hoisted to the top of the function scope anyway,
this change has no impact on this code whatsoever. By being explicit with the
location of the definition, it just adds a bit of clarity to the code.

This is also more consistent with the rest of the loops throughout this file,
which define all variables at the top of their function scope.

Finally, this change means that all variables are defined in such a way that
they could be converted to block scoped definitions (i.e. `let`) without any
impact on the code... not that I'm doing that here.
